### PR TITLE
fix: fallback document impl in old safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ An alternative API is also available to use in case legacy browsers not implemen
 
 The following is a version of the previous example implemented using the alternative API.
 
-
 ```js
 import writableDOM from "writable-dom";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "writable-dom",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -7633,6 +7634,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
## Description

Improves support for various older versions of Safari which have a bug in their `document.implementation.createHTMLDocument` implementation.

Specifically they were removing script tags from detached document contexts.
This PR adds a workaround which checks if the scripts are removed from a regular detached document and if so falls back to an iframe based implementation.
