### PR TITLE
fix: append pending inline text only after unblocked

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,11 +74,13 @@ export = function writableDOM(
       }
     },
     close() {
-      appendInlineTextIfNeeded(pendingText, inlineHostNode);
-
-      return isBlocked
+      const promise = isBlocked
         ? new Promise<void>((_) => (resolve = _))
         : Promise.resolve();
+
+      return promise.then(() => {
+        appendInlineTextIfNeeded(pendingText, inlineHostNode);
+      });
     },
   };
 


### PR DESCRIPTION
## Description

This PR fixes an issue where an inline host node would remain empty if it was the last node in the tree and a blocking node was encountered.


## Motivation and Context

Previously, the final attempt to append inline text would happen immediately once the writable stream is closed. However, there can potentially be more pending inline text added to the buffer if the writer is currently blocked waiting on an external resource. This text will never be written.

Instead, we should defer the final write until after we've become unblocked.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes

The current architecture of the test fixtures makes it difficult to reproduce the existing issue in a test case because the writer is only closed after all fixture steps are executed.
