### PR TITLE
chore: run build step when installed via git reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b && tsx build.mts",
     "change": "changeset add",
     "format": "eslint --format unix --fix .; prettier . --write --log-level=warn",
-    "prepare": "husky",
+    "prepare": "husky && npm run build",
     "release": "semantic-release",
     "report": "open ./coverage/lcov-report/index.html",
     "test": "cross-env NODE_ENV=test mocha 'src/**/__tests__/*.test.ts'",


### PR DESCRIPTION
Fixes installation via npm from Git URIs like these: https://github.com/web-fragments/web-fragments/blob/8a1f5a8ef83d13313f638ae28ce2822397db718c/packages/reframed/package.json#L16
Taken from web-fragments fork: https://github.com/marko-js/writable-dom/commit/be7248e819dd807f90adc2683aec3242c815184a
Isn't really needed much, but is a minor improvement for those who want to fork this library.